### PR TITLE
mtg-425: Error handling improvements 

### DIFF
--- a/program-states/src/state/deposit_entry.rs
+++ b/program-states/src/state/deposit_entry.rs
@@ -1,6 +1,7 @@
-use crate::state::lockup::{Lockup, LockupKind};
-
-use crate::state::LockupPeriod;
+use crate::state::{
+    lockup::{Lockup, LockupKind},
+    LockupPeriod,
+};
 use anchor_lang::prelude::*;
 
 /// Bookkeeping for a single deposit for a given mint and lockup schedule.
@@ -84,7 +85,10 @@ impl DepositEntry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::{LockupKind::Constant, LockupKind::None, LockupPeriod};
+    use crate::state::{
+        LockupKind::{Constant, None},
+        LockupPeriod,
+    };
 
     #[test]
     pub fn far_future_lockup_start_test() -> Result<()> {

--- a/programs/voter-stake-registry/tests/program_test/governance.rs
+++ b/programs/voter-stake-registry/tests/program_test/governance.rs
@@ -4,9 +4,9 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, Signer},
 };
-use spl_governance::state::realm::GoverningTokenConfigAccountArgs;
-use spl_governance::state::realm_config::GoverningTokenType;
-use spl_governance::state::{proposal, vote_record};
+use spl_governance::state::{
+    proposal, realm::GoverningTokenConfigAccountArgs, realm_config::GoverningTokenType, vote_record,
+};
 use std::rc::Rc;
 
 #[derive(Clone)]

--- a/programs/voter-stake-registry/tests/program_test/mod.rs
+++ b/programs/voter-stake-registry/tests/program_test/mod.rs
@@ -17,7 +17,7 @@ use std::{
     str::FromStr,
     sync::{Arc, RwLock},
 };
-pub use utils::*;
+pub use utils::{assert_custom_on_chain_error::AssertCustomOnChainErr, *};
 
 pub mod addin;
 pub mod cookies;

--- a/programs/voter-stake-registry/tests/test_deposit_no_locking.rs
+++ b/programs/voter-stake-registry/tests/test_deposit_no_locking.rs
@@ -1,4 +1,3 @@
-use crate::program_test::utils::assert_custom_on_chain_error::AssertCustomOnChainErr;
 use anchor_spl::token::TokenAccount;
 use mplx_staking_states::{
     error::VsrError,

--- a/programs/voter-stake-registry/tests/test_deposit_no_locking.rs
+++ b/programs/voter-stake-registry/tests/test_deposit_no_locking.rs
@@ -1,5 +1,9 @@
+use crate::program_test::utils::assert_custom_on_chain_error::AssertCustomOnChainErr;
 use anchor_spl::token::TokenAccount;
-use mplx_staking_states::state::{LockupKind, LockupPeriod};
+use mplx_staking_states::{
+    error::VsrError,
+    state::{LockupKind, LockupPeriod},
+};
 use program_test::*;
 use solana_program_test::*;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transport::TransportError};
@@ -222,7 +226,9 @@ async fn test_deposit_no_locking() -> Result<(), TransportError> {
     assert_eq!(after_withdraw1.vault, 12000);
     assert_eq!(after_withdraw1.deposit, 5000);
 
-    withdraw(5001).await.expect_err("withdrew too much");
+    withdraw(5001)
+        .await
+        .assert_on_chain_err(VsrError::InsufficientUnlockedTokens);
 
     withdraw(5000).await.unwrap();
 
@@ -236,11 +242,11 @@ async fn test_deposit_no_locking() -> Result<(), TransportError> {
     addin
         .close_deposit_entry(&voter, voter_authority, 2)
         .await
-        .expect_err("deposit not in use");
+        .assert_on_chain_err(VsrError::UnusedDepositEntryIndex);
     addin
         .close_deposit_entry(&voter, voter_authority, 1)
         .await
-        .expect_err("deposit not empty");
+        .assert_on_chain_err(VsrError::VotingTokenNonZero);
     addin
         .close_deposit_entry(&voter, voter_authority, 0)
         .await

--- a/programs/voter-stake-registry/tests/test_extend_deposit.rs
+++ b/programs/voter-stake-registry/tests/test_extend_deposit.rs
@@ -1,5 +1,8 @@
 use anchor_spl::token::TokenAccount;
-use mplx_staking_states::state::{LockupKind, LockupPeriod};
+use mplx_staking_states::{
+    error::VsrError,
+    state::{LockupKind, LockupPeriod},
+};
 use program_test::*;
 use solana_program_test::*;
 use solana_sdk::{
@@ -808,7 +811,7 @@ async fn extend_from_three_month_to_one_year() -> Result<(), TransportError> {
             50,
         )
         .await
-        .expect_err("Impossible to extend stake from existing stake (not flex) to another period");
+        .assert_on_chain_err(VsrError::ArithmeticOverflow);
 
     Ok(())
 }


### PR DESCRIPTION
added trait extension for `Result` to check specific error-codes from on-chain calls + fmt