### PR TITLE
[MTG-758] [MTG-802] Rectify close_voter ix

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   lint:
     name: Linter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -50,13 +50,13 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Linux dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config build-essential libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
 
       - name: Install stable Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -90,4 +90,4 @@ jobs:
           echo "debug = 0" >> Cargo.toml    
 
       - name: Run tests
-        run: cargo test-bpf
+        run: cargo test-sbf

--- a/program-states/src/error.rs
+++ b/program-states/src/error.rs
@@ -129,6 +129,6 @@ pub enum MplStakingError {
     #[msg("Cannot deserialize an account")]
     DeserializationError,
     // 6042 / 0x179a
-    #[msg("Invalid governing token mint")]
-    InvalidGoverningTokenMint,
+    #[msg("Invalid associated token accounts, they should match the number of regirstrar's mint configs")]
+    InvalidAssoctiatedTokenAccounts,
 }

--- a/program-states/src/error.rs
+++ b/program-states/src/error.rs
@@ -129,6 +129,6 @@ pub enum MplStakingError {
     #[msg("Cannot deserialize an account")]
     DeserializationError,
     // 6042 / 0x179a
-    #[msg("Invalid associated token accounts, they should match the number of regirstrar's mint configs")]
+    #[msg("Invalid associated token accounts, they should match the number mint configs of a registrar")]
     InvalidAssoctiatedTokenAccounts,
 }

--- a/program-states/src/error.rs
+++ b/program-states/src/error.rs
@@ -129,6 +129,6 @@ pub enum MplStakingError {
     #[msg("Cannot deserialize an account")]
     DeserializationError,
     // 6042 / 0x179a
-    #[msg("Invalid associated token accounts, they should match the number mint configs of a registrar")]
+    #[msg("Invalid associated token accounts, they should match the number mint configs of a registrar and must be passed in the strict order")]
     InvalidAssoctiatedTokenAccounts,
 }

--- a/program-states/src/state/registrar.rs
+++ b/program-states/src/state/registrar.rs
@@ -38,10 +38,12 @@ impl Registrar {
                 if !voting_mint_config.in_use() {
                     return Ok(sum);
                 }
+
                 let mint_account = mint_accounts
                     .iter()
-                    .find(|a| a.key() == voting_mint_config.mint)
+                    .find(|mint_account| mint_account.key() == voting_mint_config.mint)
                     .ok_or_else(|| error!(MplStakingError::VotingMintNotFound))?;
+
                 let mint = Account::<Mint>::try_from(mint_account)?;
                 sum = sum
                     .checked_add(mint.supply)

--- a/programs/voter-stake-registry/src/instructions/close_voter.rs
+++ b/programs/voter-stake-registry/src/instructions/close_voter.rs
@@ -116,11 +116,6 @@ pub fn close_voter<'info>(ctx: Context<'_, '_, '_, 'info, CloseVoter<'info>>) ->
         });
 
         for (index, calculated_ata_to_close) in calculated_atas_to_close.enumerate() {
-            require!(
-                ctx.remaining_accounts.len() > index,
-                MplStakingError::InvalidAssoctiatedTokenAccounts
-            );
-
             let ata_info_to_close = ctx.remaining_accounts[index].to_account_info();
             require_keys_eq!(
                 *ata_info_to_close.key,

--- a/programs/voter-stake-registry/src/instructions/configure_voting_mint.rs
+++ b/programs/voter-stake-registry/src/instructions/configure_voting_mint.rs
@@ -24,7 +24,7 @@ pub struct ConfigureVotingMint<'info> {
 /// exchange rate per mint.
 ///
 /// * `idx`: index of the rate to be set
-/// * `grand_authority`: The keypair that might be an authority for Grand/Clawback
+/// * `grant_authority`: The keypair that might be an authority for Grant/Clawback
 ///
 /// This instruction can be called several times for the same mint and index to
 /// change the voting mint configuration.

--- a/programs/voter-stake-registry/tests/close_voter.rs
+++ b/programs/voter-stake-registry/tests/close_voter.rs
@@ -1,0 +1,598 @@
+use anchor_spl::token::TokenAccount;
+use assert_custom_on_chain_error::AssertCustomOnChainErr;
+use mplx_staking_states::{
+    error::MplStakingError,
+    state::{LockupKind, LockupPeriod},
+};
+use program_test::*;
+use solana_program_test::*;
+use solana_sdk::{signature::Keypair, signer::Signer, transport::TransportError};
+
+mod program_test;
+
+#[tokio::test]
+async fn two_the_same_voting_mints_fail() -> Result<(), TransportError> {
+    let context = TestContext::new().await;
+
+    let payer = &context.users[0].key;
+    let realm_authority = Keypair::new();
+    let realm = context
+        .governance
+        .create_realm(
+            "testrealm",
+            realm_authority.pubkey(),
+            &context.mints[0],
+            payer,
+            &context.addin.program_id,
+        )
+        .await;
+
+    let deposit_authority = &context.users[1].key;
+    let token_owner_record = realm
+        .create_token_owner_record(deposit_authority.pubkey(), payer)
+        .await;
+
+    let fill_authority = Keypair::from_bytes(&context.users[3].key.to_bytes()).unwrap();
+    let distribution_authority = Keypair::new();
+    let (registrar, rewards_pool) = context
+        .addin
+        .create_registrar(
+            &realm,
+            &realm_authority,
+            payer,
+            &fill_authority.pubkey(),
+            &distribution_authority.pubkey(),
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let mngo_voting_mint = context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            0,
+            &context.mints[0],
+            None,
+            Some(&[context.mints[1].pubkey.unwrap()]),
+        )
+        .await;
+
+    context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            1,
+            &context.mints[1],
+            None,
+            Some(&[context.mints[0].pubkey.unwrap()]),
+        )
+        .await;
+
+    // TODO: ??? voter_authority == deposit_authority ???
+    let voter_authority = deposit_authority;
+    let (deposit_mining, _) = find_deposit_mining_addr(
+        &context.rewards.program_id,
+        &voter_authority.pubkey(),
+        &rewards_pool,
+    );
+
+    let voter = context
+        .addin
+        .create_voter(
+            &registrar,
+            &token_owner_record,
+            voter_authority,
+            payer,
+            &rewards_pool,
+            &deposit_mining,
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let balance_initial = voter.deposit_amount(&context.solana, 0).await;
+    assert_eq!(balance_initial, 0);
+
+    context
+        .addin
+        .create_deposit_entry(
+            &registrar,
+            &voter,
+            &voter,
+            &mngo_voting_mint,
+            0,
+            LockupKind::None,
+            LockupPeriod::None,
+        )
+        .await?;
+
+    // test deposit and withdraw
+    let reference_account = context.users[1].token_accounts[0];
+    context
+        .addin
+        .deposit(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    context
+        .addin
+        .withdraw(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    let mints = &[context.mints[0].clone(), context.mints[0].clone()];
+    context
+        .addin
+        .close_voter(
+            &registrar,
+            &voter,
+            &mints[..],
+            voter_authority,
+            &context.rewards.program_id,
+        )
+        .await
+        .assert_on_chain_err(MplStakingError::InvalidAssoctiatedTokenAccounts);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn zero_ata_passed_instead_of_two() -> Result<(), TransportError> {
+    let context = TestContext::new().await;
+
+    let payer = &context.users[0].key;
+    let realm_authority = Keypair::new();
+    let realm = context
+        .governance
+        .create_realm(
+            "testrealm",
+            realm_authority.pubkey(),
+            &context.mints[0],
+            payer,
+            &context.addin.program_id,
+        )
+        .await;
+
+    let deposit_authority = &context.users[1].key;
+    let token_owner_record = realm
+        .create_token_owner_record(deposit_authority.pubkey(), payer)
+        .await;
+
+    let fill_authority = Keypair::from_bytes(&context.users[3].key.to_bytes()).unwrap();
+    let distribution_authority = Keypair::new();
+    let (registrar, rewards_pool) = context
+        .addin
+        .create_registrar(
+            &realm,
+            &realm_authority,
+            payer,
+            &fill_authority.pubkey(),
+            &distribution_authority.pubkey(),
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let mngo_voting_mint = context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            0,
+            &context.mints[0],
+            None,
+            Some(&[context.mints[1].pubkey.unwrap()]),
+        )
+        .await;
+
+    context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            1,
+            &context.mints[1],
+            None,
+            Some(&[context.mints[0].pubkey.unwrap()]),
+        )
+        .await;
+
+    // TODO: ??? voter_authority == deposit_authority ???
+    let voter_authority = deposit_authority;
+    let (deposit_mining, _) = find_deposit_mining_addr(
+        &context.rewards.program_id,
+        &voter_authority.pubkey(),
+        &rewards_pool,
+    );
+
+    let voter = context
+        .addin
+        .create_voter(
+            &registrar,
+            &token_owner_record,
+            voter_authority,
+            payer,
+            &rewards_pool,
+            &deposit_mining,
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let balance_initial = voter.deposit_amount(&context.solana, 0).await;
+    assert_eq!(balance_initial, 0);
+
+    context
+        .addin
+        .create_deposit_entry(
+            &registrar,
+            &voter,
+            &voter,
+            &mngo_voting_mint,
+            0,
+            LockupKind::None,
+            LockupPeriod::None,
+        )
+        .await?;
+
+    // test deposit and withdraw
+    let reference_account = context.users[1].token_accounts[0];
+    context
+        .addin
+        .deposit(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    context
+        .addin
+        .withdraw(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    let mints = &[];
+    context
+        .addin
+        .close_voter(
+            &registrar,
+            &voter,
+            &mints[..],
+            voter_authority,
+            &context.rewards.program_id,
+        )
+        .await
+        .assert_on_chain_err(MplStakingError::InvalidAssoctiatedTokenAccounts);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn one_ata_passed_instead_of_two() -> Result<(), TransportError> {
+    let context = TestContext::new().await;
+
+    let payer = &context.users[0].key;
+    let realm_authority = Keypair::new();
+    let realm = context
+        .governance
+        .create_realm(
+            "testrealm",
+            realm_authority.pubkey(),
+            &context.mints[0],
+            payer,
+            &context.addin.program_id,
+        )
+        .await;
+
+    let deposit_authority = &context.users[1].key;
+    let token_owner_record = realm
+        .create_token_owner_record(deposit_authority.pubkey(), payer)
+        .await;
+
+    let fill_authority = Keypair::from_bytes(&context.users[3].key.to_bytes()).unwrap();
+    let distribution_authority = Keypair::new();
+    let (registrar, rewards_pool) = context
+        .addin
+        .create_registrar(
+            &realm,
+            &realm_authority,
+            payer,
+            &fill_authority.pubkey(),
+            &distribution_authority.pubkey(),
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let mngo_voting_mint = context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            0,
+            &context.mints[0],
+            None,
+            Some(&[context.mints[1].pubkey.unwrap()]),
+        )
+        .await;
+
+    context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            1,
+            &context.mints[1],
+            None,
+            Some(&[context.mints[0].pubkey.unwrap()]),
+        )
+        .await;
+
+    // TODO: ??? voter_authority == deposit_authority ???
+    let voter_authority = deposit_authority;
+    let (deposit_mining, _) = find_deposit_mining_addr(
+        &context.rewards.program_id,
+        &voter_authority.pubkey(),
+        &rewards_pool,
+    );
+
+    let voter = context
+        .addin
+        .create_voter(
+            &registrar,
+            &token_owner_record,
+            voter_authority,
+            payer,
+            &rewards_pool,
+            &deposit_mining,
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let balance_initial = voter.deposit_amount(&context.solana, 0).await;
+    assert_eq!(balance_initial, 0);
+
+    context
+        .addin
+        .create_deposit_entry(
+            &registrar,
+            &voter,
+            &voter,
+            &mngo_voting_mint,
+            0,
+            LockupKind::None,
+            LockupPeriod::None,
+        )
+        .await?;
+
+    // test deposit and withdraw
+    let reference_account = context.users[1].token_accounts[0];
+    context
+        .addin
+        .deposit(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    context
+        .addin
+        .withdraw(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    let mints = &[context.mints[0].clone()];
+    context
+        .addin
+        .close_voter(
+            &registrar,
+            &voter,
+            &mints[..],
+            voter_authority,
+            &context.rewards.program_id,
+        )
+        .await
+        .assert_on_chain_err(MplStakingError::InvalidAssoctiatedTokenAccounts);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn success() -> Result<(), TransportError> {
+    let context = TestContext::new().await;
+
+    let payer = &context.users[0].key;
+    let realm_authority = Keypair::new();
+    let realm = context
+        .governance
+        .create_realm(
+            "testrealm",
+            realm_authority.pubkey(),
+            &context.mints[0],
+            payer,
+            &context.addin.program_id,
+        )
+        .await;
+
+    let deposit_authority = &context.users[1].key;
+    let token_owner_record = realm
+        .create_token_owner_record(deposit_authority.pubkey(), payer)
+        .await;
+
+    let fill_authority = Keypair::from_bytes(&context.users[3].key.to_bytes()).unwrap();
+    let distribution_authority = Keypair::new();
+    let (registrar, rewards_pool) = context
+        .addin
+        .create_registrar(
+            &realm,
+            &realm_authority,
+            payer,
+            &fill_authority.pubkey(),
+            &distribution_authority.pubkey(),
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let mngo_voting_mint = context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            0,
+            &context.mints[0],
+            None,
+            Some(&[context.mints[1].pubkey.unwrap()]),
+        )
+        .await;
+
+    context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            1,
+            &context.mints[1],
+            None,
+            Some(&[context.mints[0].pubkey.unwrap()]),
+        )
+        .await;
+
+    // TODO: ??? voter_authority == deposit_authority ???
+    let voter_authority = deposit_authority;
+    let (deposit_mining, _) = find_deposit_mining_addr(
+        &context.rewards.program_id,
+        &voter_authority.pubkey(),
+        &rewards_pool,
+    );
+
+    let voter = context
+        .addin
+        .create_voter(
+            &registrar,
+            &token_owner_record,
+            voter_authority,
+            payer,
+            &rewards_pool,
+            &deposit_mining,
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let balance_initial = voter.deposit_amount(&context.solana, 0).await;
+    assert_eq!(balance_initial, 0);
+
+    context
+        .addin
+        .create_deposit_entry(
+            &registrar,
+            &voter,
+            &voter,
+            &mngo_voting_mint,
+            0,
+            LockupKind::None,
+            LockupPeriod::None,
+        )
+        .await?;
+
+    // test deposit and withdraw
+    let reference_account = context.users[1].token_accounts[0];
+    context
+        .addin
+        .deposit(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    context
+        .addin
+        .withdraw(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    let lamports_before = context
+        .solana
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_balance(voter_authority.pubkey())
+        .await?;
+
+    context
+        .addin
+        .close_voter(
+            &registrar,
+            &voter,
+            &context.mints[..],
+            voter_authority,
+            &context.rewards.program_id,
+        )
+        .await?;
+
+    let lamports_after = context
+        .solana
+        .context
+        .borrow_mut()
+        .banks_client
+        .get_balance(voter_authority.pubkey())
+        .await?;
+    assert!(lamports_after > lamports_before);
+
+    Ok(())
+}

--- a/programs/voter-stake-registry/tests/close_voter.rs
+++ b/programs/voter-stake-registry/tests/close_voter.rs
@@ -138,6 +138,7 @@ async fn two_the_same_voting_mints_fail() -> Result<(), TransportError> {
         .await?;
 
     let mints = &[context.mints[0].clone(), context.mints[0].clone()];
+
     context
         .addin
         .close_voter(
@@ -593,6 +594,149 @@ async fn success() -> Result<(), TransportError> {
         .get_balance(voter_authority.pubkey())
         .await?;
     assert!(lamports_after > lamports_before);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn wrong_order_of_passed_in_ata() -> Result<(), TransportError> {
+    let context = TestContext::new().await;
+
+    let payer = &context.users[0].key;
+    let realm_authority = Keypair::new();
+    let realm = context
+        .governance
+        .create_realm(
+            "testrealm",
+            realm_authority.pubkey(),
+            &context.mints[0],
+            payer,
+            &context.addin.program_id,
+        )
+        .await;
+
+    let deposit_authority = &context.users[1].key;
+    let token_owner_record = realm
+        .create_token_owner_record(deposit_authority.pubkey(), payer)
+        .await;
+
+    let fill_authority = Keypair::from_bytes(&context.users[3].key.to_bytes()).unwrap();
+    let distribution_authority = Keypair::new();
+    let (registrar, rewards_pool) = context
+        .addin
+        .create_registrar(
+            &realm,
+            &realm_authority,
+            payer,
+            &fill_authority.pubkey(),
+            &distribution_authority.pubkey(),
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let mngo_voting_mint = context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            0,
+            &context.mints[0],
+            None,
+            Some(&[context.mints[1].pubkey.unwrap()]),
+        )
+        .await;
+
+    context
+        .addin
+        .configure_voting_mint(
+            &registrar,
+            &realm_authority,
+            payer,
+            1,
+            &context.mints[1],
+            None,
+            Some(&[context.mints[0].pubkey.unwrap()]),
+        )
+        .await;
+
+    // TODO: ??? voter_authority == deposit_authority ???
+    let voter_authority = deposit_authority;
+    let (deposit_mining, _) = find_deposit_mining_addr(
+        &context.rewards.program_id,
+        &voter_authority.pubkey(),
+        &rewards_pool,
+    );
+
+    let voter = context
+        .addin
+        .create_voter(
+            &registrar,
+            &token_owner_record,
+            voter_authority,
+            payer,
+            &rewards_pool,
+            &deposit_mining,
+            &context.rewards.program_id,
+        )
+        .await;
+
+    let balance_initial = voter.deposit_amount(&context.solana, 0).await;
+    assert_eq!(balance_initial, 0);
+
+    context
+        .addin
+        .create_deposit_entry(
+            &registrar,
+            &voter,
+            &voter,
+            &mngo_voting_mint,
+            0,
+            LockupKind::None,
+            LockupPeriod::None,
+        )
+        .await?;
+
+    // test deposit and withdraw
+    let reference_account = context.users[1].token_accounts[0];
+    context
+        .addin
+        .deposit(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    context
+        .addin
+        .withdraw(
+            &registrar,
+            &voter,
+            &mngo_voting_mint,
+            deposit_authority,
+            reference_account,
+            0,
+            10000,
+        )
+        .await?;
+
+    let mints = &[context.mints[1].clone(), context.mints[0].clone()];
+    context
+        .addin
+        .close_voter(
+            &registrar,
+            &voter,
+            &mints[..],
+            voter_authority,
+            &context.rewards.program_id,
+        )
+        .await
+        .assert_on_chain_err(MplStakingError::InvalidAssoctiatedTokenAccounts);
 
     Ok(())
 }

--- a/programs/voter-stake-registry/tests/program_test/mod.rs
+++ b/programs/voter-stake-registry/tests/program_test/mod.rs
@@ -141,7 +141,7 @@ impl TestContext {
                 unit: 10u64.pow(6) as f64,
                 base_lot: 100_f64,
                 quote_lot: 10_f64,
-                pubkey: None, //Some(mngo_token::ID),
+                pubkey: Some(Pubkey::new_unique()), //Some(mngo_token::ID),
                 authority: Keypair::new(),
             }, // symbol: "MNGO".to_string()
             MintCookie {
@@ -150,20 +150,14 @@ impl TestContext {
                 unit: 10u64.pow(6) as f64,
                 base_lot: 0 as f64,
                 quote_lot: 0 as f64,
-                pubkey: None,
+                pubkey: Some(Pubkey::new_unique()),
                 authority: Keypair::new(),
             }, // symbol: "USDC".to_string()
         ];
         // Add mints in loop
         for mint in mints.iter_mut() {
-            let mint_pk = if mint.pubkey.is_none() {
-                Pubkey::new_unique()
-            } else {
-                mint.pubkey.unwrap()
-            };
-
             test.add_packable_account(
-                mint_pk,
+                mint.pubkey.unwrap(),
                 u32::MAX as u64,
                 &Mint {
                     is_initialized: true,
@@ -173,7 +167,7 @@ impl TestContext {
                 },
                 &spl_token::id(),
             );
-            mint.pubkey = Some(mint_pk);
+            mint.pubkey = Some(mint.pubkey.unwrap());
         }
         let quote_index = mints.len() - 1;
 

--- a/programs/voter-stake-registry/tests/test_basic.rs
+++ b/programs/voter-stake-registry/tests/test_basic.rs
@@ -224,7 +224,7 @@ async fn test_basic() -> Result<(), TransportError> {
         .close_voter(
             &registrar,
             &voter,
-            &mngo_voting_mint,
+            &context.mints[..],
             voter_authority,
             &context.rewards.program_id,
         )
@@ -380,7 +380,7 @@ async fn close_voter_with_locked_tokens_should_fail() -> Result<(), TransportErr
         .close_voter(
             &registrar,
             &voter,
-            &mngo_voting_mint,
+            &context.mints[..],
             voter_authority,
             &context.rewards.program_id,
         )


### PR DESCRIPTION
To close `voter` and its `ATA`  an end-user need to pass in all `ATA` gathered from mints of a `Registrar`; even if those `ATA` don't exist, their addresses may still be calculated.